### PR TITLE
Fix on string replacements for ocelot tags

### DIFF
--- a/lib/projectify.rb
+++ b/lib/projectify.rb
@@ -137,11 +137,6 @@ class Projectify
     result = JSON.parse(request.body)
 
     if result["tag_name"] != false
-      # Handle Ocelot releases.
-      if repository == "Ocelot"
-        result["tag_name"].gsub!(/.nd/, "")
-        result["tag_name"] = "#{result["tag_name"]}.om"
-      end
       return result["tag_name"]
     end
 


### PR DESCRIPTION
I removed those string replacements.
For now we have to make sure that the latest release is the release of the omega branch.
Keep in mind that this is temporary.
closes #24 
